### PR TITLE
Add SwiftUI Live Activity prototype

### DIFF
--- a/MediaUploadApp/Info.plist
+++ b/MediaUploadApp/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>MediaUpload</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.mediaupload</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string></string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/MediaUploadApp/MediaUploadApp.swift
+++ b/MediaUploadApp/MediaUploadApp.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import ActivityKit
+
+@main
+struct MediaUploadApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Live Activity Prototype")
+                .font(.title)
+            Button("Start Upload") {
+                startUploadActivity()
+            }
+        }
+        .padding()
+    }
+
+    func startUploadActivity() {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let attributes = MediaUploadAttributes()
+        let initialState = MediaUploadAttributes.ContentState(progress: 0)
+        do {
+            let activity = try Activity<MediaUploadAttributes>.request(
+                attributes: attributes,
+                contentState: initialState,
+                pushType: nil)
+            Task {
+                for i in 1...90 {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    await activity.update(using: .init(progress: Double(i) / 90.0))
+                }
+                await activity.end(using: .init(progress: 1.0), dismissalPolicy: .immediate)
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/MediaUploadWidget/Info.plist
+++ b/MediaUploadWidget/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>MediaUploadWidget</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.mediaupload.widget</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).MediaUploadWidget</string>
+    </dict>
+</dict>
+</plist>

--- a/MediaUploadWidget/MediaUploadWidget.swift
+++ b/MediaUploadWidget/MediaUploadWidget.swift
@@ -1,0 +1,46 @@
+import WidgetKit
+import SwiftUI
+import ActivityKit
+
+struct MediaUploadWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: MediaUploadAttributes.self) { context in
+            HStack {
+                Image(systemName: "photo")
+                Text("Media are uploading")
+                Spacer()
+                ProgressView(value: context.state.progress)
+                    .progressViewStyle(.circular)
+            }
+            .padding()
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "photo")
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text("Media are uploading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    ProgressView(value: context.state.progress)
+                        .progressViewStyle(.circular)
+                }
+            } compactLeading: {
+                Image(systemName: "photo")
+            } compactTrailing: {
+                ProgressView(value: context.state.progress)
+                    .progressViewStyle(.circular)
+            } minimal: {
+                ProgressView(value: context.state.progress)
+                    .progressViewStyle(.circular)
+            }
+        }
+    }
+}
+
+@main
+struct MediaUploadWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        MediaUploadWidget()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Media Upload Live Activity Prototype
+
+This repository contains example SwiftUI code for an iOS app and Live Activity widget extension. It demonstrates how a Live Activity could look while media are uploading.
+
+## Features
+- **Dynamic Island support** following Apple's Human Interface Guidelines.
+- Shows a logo on the left, text "Media are uploading" in the center, and a circular loader on the right when expanded.
+- In the minimal state (unexpanded Dynamic Island) only the logo and loader are visible.
+- The loader animates for 90 seconds as a prototype.
+
+## Usage
+1. Install [Xcode](https://developer.apple.com/xcode/).
+2. Create a new iOS app project with a widget extension (using SwiftUI & ActivityKit).
+3. Replace the generated source files with the contents of this repository:
+   - `Shared/MediaUploadActivity.swift`
+   - `MediaUploadApp/MediaUploadApp.swift`
+   - `MediaUploadApp/Info.plist`
+   - `MediaUploadWidget/MediaUploadWidget.swift`
+   - `MediaUploadWidget/Info.plist`
+4. Build and run the project on a device or simulator supporting Live Activities (iOS 16.1+).
+
+This code does not rely on any backend or external data and is intended purely for prototyping the UI.

--- a/Shared/MediaUploadActivity.swift
+++ b/Shared/MediaUploadActivity.swift
@@ -1,0 +1,7 @@
+import ActivityKit
+
+struct MediaUploadAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var progress: Double
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder `Info.plist` for the app and widget
- add sample SwiftUI app launching a 90‑second Live Activity
- add widget extension showing a Dynamic Island design
- share `MediaUploadAttributes` across targets
- document manual setup steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a260c59c8832f80578b12fbc553f0